### PR TITLE
Lagt til properties for config av central-publishing-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
         <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
+        <central-publishing-maven-plugin.ignorePublishedComponents>false</central-publishing-maven-plugin.ignorePublishedComponents>
+        <central-publishing-maven-plugin.waitUntil>published</central-publishing-maven-plugin.waitUntil>
+        <central-publishing-maven-plugin.waitMaxTime>1800</central-publishing-maven-plugin.waitMaxTime>
     </properties>
 
     <dependencyManagement>
@@ -201,7 +204,9 @@
                 <configuration>
                     <publishingServerId>portal-ossrh</publishingServerId>
                     <autoPublish>true</autoPublish>
-                    <waitUntil>published</waitUntil>
+                    <waitUntil>${central-publishing-maven-plugin.waitUntil}</waitUntil>
+                    <waitMaxTime>${central-publishing-maven-plugin.waitMaxTime}</waitMaxTime>
+                    <ignorePublishedComponents>${central-publishing-maven-plugin.ignorePublishedComponents}</ignorePublishedComponents>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Publisering av enkelte releaser feiler grunnet at det tar for lang tid å publisere. Timeout er default 30 minutter.
Har lagt til mulighet for å skru litt på config på `central-publishing-maven-plugin` i den enkelte pom for å komme seg rundt dette.