### PR TITLE
Migrer fra Jenkins til GitHub Actions (libPipelineMvnCentral*)

### DIFF
--- a/.github/workflows/autobuild-lib.yml
+++ b/.github/workflows/autobuild-lib.yml
@@ -20,4 +20,5 @@ jobs:
     with:
       java_version: 'java17'
       is_release: false
+      runner: 'ubuntu-latest'
     secrets: inherit

--- a/.github/workflows/autobuild-lib.yml
+++ b/.github/workflows/autobuild-lib.yml
@@ -1,0 +1,23 @@
+name: Autobuild library for all branches, does not release
+
+on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+      - '!combined-prs-branch'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/'))
+    uses: ks-no/github-actions-public/.github/workflows/java-library-build.yml@main
+    with:
+      java_version: 'java17'
+      is_release: false
+    secrets: inherit

--- a/.github/workflows/build-release-lib.yml
+++ b/.github/workflows/build-release-lib.yml
@@ -35,4 +35,5 @@ jobs:
       version: ${{ inputs.version }}
       is_release: ${{ inputs.is_release }}
       reviewer: ${{ inputs.reviewer }}
+      runner: 'ubuntu-latest'
     secrets: inherit

--- a/.github/workflows/build-release-lib.yml
+++ b/.github/workflows/build-release-lib.yml
@@ -1,0 +1,38 @@
+name: Build and Release Library
+
+on:
+  workflow_dispatch:
+    inputs:
+      # Velg enten semver_increment ELLER version - ikke begge.
+      # Om begge settes vil den reusable workflowen feile.
+      semver_increment:
+        description: 'Select semver increment (next major/minor/patch). Fails if version is also set.'
+        required: false
+        type: choice
+        options:
+          - ''
+          - next major
+          - next minor
+          - next patch
+      version:
+        description: 'Exact version number to release. Fails if semver_increment is also set.'
+        required: false
+      is_release:
+        description: 'Is this a release build?'
+        required: true
+        type: boolean
+        default: false
+      reviewer:
+        description: 'GitHub username of the reviewer'
+        required: true
+
+jobs:
+  build:
+    uses: ks-no/github-actions-public/.github/workflows/java-library-build.yml@main
+    with:
+      java_version: 'java17'
+      semver_increment: ${{ inputs.semver_increment }}
+      version: ${{ inputs.version }}
+      is_release: ${{ inputs.is_release }}
+      reviewer: ${{ inputs.reviewer }}
+    secrets: inherit

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,0 @@
-libPipelineMvnCentralJdk17(dtProjectId: "11d42a7f-16c9-4e6a-90b9-4c322accc014")


### PR DESCRIPTION
Migrerer fra Jenkins (`libPipelineMvnCentral*`) til GitHub Actions.

Legger til `autobuild-lib.yml` og `build-release-lib.yml`, sletter `Jenkinsfile`.